### PR TITLE
공통 응답 바디 개발

### DIFF
--- a/src/main/java/com/one/devhash/exception/FailedConvertingException.java
+++ b/src/main/java/com/one/devhash/exception/FailedConvertingException.java
@@ -1,0 +1,10 @@
+package com.one.devhash.exception;
+
+import com.one.devhash.global.error.exception.ErrorCode;
+import com.one.devhash.global.error.exception.InvalidValueException;
+
+public class FailedConvertingException extends InvalidValueException {
+    public FailedConvertingException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/one/devhash/global/error/ErrorResponse.java
+++ b/src/main/java/com/one/devhash/global/error/ErrorResponse.java
@@ -1,0 +1,84 @@
+package com.one.devhash.global.error;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.one.devhash.global.error.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+    private int code;
+    private String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<FieldError> errors;
+
+    private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+        this.message = code.getMessage();
+        this.code = code.getStatus();
+        this.errors = errors;
+    }
+
+    private ErrorResponse(final ErrorCode code) {
+        this.message = code.getMessage();
+        this.code = code.getStatus();
+        this.errors = new ArrayList<>();
+    }
+
+
+    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+        final String value = e.getValue() == null ? "" : e.getValue().toString();
+        final List<FieldError> errors = FieldError.of(e.getName(), value, e.getErrorCode());
+        return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
+    }
+
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+        private FieldError(final String field, final String value, final String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(final String field, final String value, final String reason) {
+            List<FieldError> fieldErrors = new ArrayList<>();
+            fieldErrors.add(new FieldError(field, value, reason));
+            return fieldErrors;
+        }
+
+        private static List<FieldError> of(final BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+
+
+}

--- a/src/main/java/com/one/devhash/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/one/devhash/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,71 @@
+package com.one.devhash.global.error;
+
+import com.one.devhash.global.error.exception.BusinessException;
+import com.one.devhash.global.error.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.nio.file.AccessDeniedException;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("handleMethodArgumentNotValidException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_USERNAME, e.getBindingResult());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.error("handleBindException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_USERNAME, e.getBindingResult());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException", e);
+        final ErrorResponse response = ErrorResponse.of(e);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("handleAccessDeniedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.HANDLE_ACCESS_DENIED.getStatus()));
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+        log.error("handleEntityNotFoundException", e);
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("handleEntityNotFoundException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/one/devhash/global/error/exception/BusinessException.java
+++ b/src/main/java/com/one/devhash/global/error/exception/BusinessException.java
@@ -1,0 +1,21 @@
+package com.one.devhash.global.error.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+}

--- a/src/main/java/com/one/devhash/global/error/exception/EntityNotFoundException.java
+++ b/src/main/java/com/one/devhash/global/error/exception/EntityNotFoundException.java
@@ -1,0 +1,7 @@
+package com.one.devhash.global.error.exception;
+
+public class EntityNotFoundException extends BusinessException {
+    public EntityNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/one/devhash/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/one/devhash/global/error/exception/ErrorCode.java
@@ -1,0 +1,44 @@
+package com.one.devhash.global.error.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum ErrorCode {
+
+    // 공통
+    INVALID_INPUT_VALUE(400, " Invalid Input Value"),
+    METHOD_NOT_ALLOWED(405,  " Invalid Input Value"),
+    ENTITY_NOT_FOUND(404,  " Entity Not Found"),
+    INTERNAL_SERVER_ERROR(500, "Server Error"),
+    INVALID_TYPE_VALUE(400, " Invalid Type Value"),
+
+    // 유저
+    HANDLE_ACCESS_DENIED(403, "로그인이 필요합니다."),
+    INVALID_INPUT_USERNAME(400, "닉네임을 3자 이상 입력하세요"),
+    NOTEQUAL_INPUT_PASSWORD(400,  "비밀번호가 일치하지 않습니다"),
+    INVALID_PASSWORD(400,  "비밀번호를 8자 이상 입력하세요"),
+    INVALID_USERNAME(400,  "알파벳 대소문자와 숫자로만 입력하세요"),
+    NOT_AUTHORIZED(403, "작성자만 수정 및 삭제를 할 수 있습니다."),
+    USERNAME_DUPLICATION(400, "이미 등록된 아이디입니다."),
+    LOGIN_INPUT_INVALID(400, "로그인 정보를 다시 확인해주세요."),
+    NOTFOUND_USER(404,  "해당 이름의 유저가 존재하지 않습니다."),
+
+    // 게시글
+    NOTFOUND_POST(404, "해당 게시글이 존재하지 않습니다."),
+    CONVERTING_FAILED(400, "파일 변환에 실패했습니다."),
+    ;
+    private final String message;
+    private final int status;
+
+    ErrorCode(final int status, final String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+    public int getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/one/devhash/global/error/exception/InvalidValueException.java
+++ b/src/main/java/com/one/devhash/global/error/exception/InvalidValueException.java
@@ -1,0 +1,9 @@
+package com.one.devhash.global.error.exception;
+
+public class InvalidValueException extends BusinessException {
+
+    public InvalidValueException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/com/one/devhash/global/response/ApiUtils.java
+++ b/src/main/java/com/one/devhash/global/response/ApiUtils.java
@@ -1,0 +1,7 @@
+package com.one.devhash.global.response;
+
+public class ApiUtils {
+    public static <T> CommonResponse<T> success(int code, T result) {
+        return new CommonResponse<>(code, true, result);
+    }
+}

--- a/src/main/java/com/one/devhash/global/response/CommonResponse.java
+++ b/src/main/java/com/one/devhash/global/response/CommonResponse.java
@@ -1,0 +1,13 @@
+package com.one.devhash.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+public record CommonResponse<T>(int code, boolean success, @JsonInclude(JsonInclude.Include.NON_NULL) T result) {
+    @Builder
+    public CommonResponse(int code, boolean success, T result) {
+        this.code = code;
+        this.success = success;
+        this.result = result;
+    }
+}


### PR DESCRIPTION
- `CommonResponse` 클래스를 만들어 성공했을 때 공통적으로 code, success, result 의 형태로 보낼 수 있도록 만들었습니다. 
- 에러가 발생할 때 공통적으로 에러 핸들링을 할 수 있도록 처리했습니다. 
- `enum` 에 있는 에러 코드는 필요할 때 추가해서 작성해주시면 됩니다. 
- `FailedConvertingException` 과 같은 구체적인 클래스명이 필요한 경우 exception 폴더 안에 만들어 주시면 됩니다. 
- 아래 문서를 참고해주시고 이해 안되거나 어려운 게 있으면 질문해주세요. 그리고 문서에 틀린 부분이나 개선할 점이 있는 경우에 말씀해주시면 감사하겠습니다. 
https://velog.io/@wisdom08/스프링부트-공통-응답-API-개발-과정

This closes #2 